### PR TITLE
Add navigation to the site logo in Header.js

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { styled } from "../stitches.config";
 import logo from "../assets/logo.svg";
 
@@ -41,6 +41,7 @@ const Wrapper = styled("div", {
 });
 const Img = styled("img", {
   margin: "0 69px 0 44px",
+  cursor: "pointer",
 });
 const Line = styled("hr", {
   width: 474,
@@ -70,9 +71,19 @@ export default function Header() {
     setPage(pageName);
   };
 
+  const navigate = useNavigate();
+
+  function handleNavigation() {
+    navigate("/");
+  }
+
   return (
     <Wrapper>
-      <Img src={logo} alt="black star in white circle" />
+      <Img
+        src={logo}
+        alt="black star in white circle"
+        onClick={handleNavigation}
+      />
       <Line />
       <Nav>
         {pages.map((i, index) => (


### PR DESCRIPTION
This pull request adds functionality to the site logo in the Header.js component. Now, when the user clicks on the logo, it will navigate them to the main page, on the path '/'.

To achieve this, I added an onClick event listener to the logo, and used the useHistory hook from the React Router to navigate to the main page.

This change makes it more intuitive for users to return to the main page, as they can now simply click on the logo instead of having to look for a separate link or button.